### PR TITLE
Bump `actions/cache` to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16.5'
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com>

Closes #none

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Because the `v2` supports the glob pattern, it should be updated to `*`.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
